### PR TITLE
Haskell with Nix: fix flake.nix syntax by adding missing final "}"

### DIFF
--- a/Software/Haskell/HaskellWithNix.md
+++ b/Software/Haskell/HaskellWithNix.md
@@ -80,6 +80,7 @@ Then create the following [[Flakes|Nix flake]]:
       ) // {
       overlays.default = overlay;
     };
+}
 ```
 
 Now you're probably thinking:


### PR DESCRIPTION
Fix syntax of the `flake.nix` proposed in [«Using Nix for Haskell projects»](https://ners.ch/Software/Haskell/HaskellWithNix) by adding the final closing curly brace, which was missing until now.